### PR TITLE
feat(plan): add plan, feature and subscription CRUD

### DIFF
--- a/internal/feature/controller.go
+++ b/internal/feature/controller.go
@@ -1,0 +1,124 @@
+package feature
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/charmbracelet/log"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/jourloy/nutri-backend/internal/auth"
+)
+
+var (
+	logger = log.NewWithOptions(os.Stderr, log.Options{
+		Prefix: "[feat]",
+		Level:  log.DebugLevel,
+	})
+)
+
+type Controller struct {
+	service Service
+}
+
+func NewController() *Controller {
+	return &Controller{service: NewService()}
+}
+
+func (c *Controller) RegisterRoutes(router chi.Router) {
+	router.Route("/feature", func(r chi.Router) {
+		r.Post("/", c.Create)
+		r.Put("/", c.Update)
+		r.Delete("/{key}", c.Delete)
+	})
+
+	logger.Info("╔═════ Feature")
+	logger.Info("║   POST /")
+	logger.Info("║    PUT /")
+	logger.Info("║ DELETE /{key}")
+	logger.Info("╚═════")
+}
+
+func (c *Controller) Create(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	var f Feature
+	if err := json.NewDecoder(r.Body).Decode(&f); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp, err := c.service.Create(context.Background(), f)
+	if err != nil {
+		logger.Error("Error creating feature", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Update(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	var f Feature
+	if err := json.NewDecoder(r.Body).Decode(&f); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp, err := c.service.Update(context.Background(), f)
+	if err != nil {
+		logger.Error("Error updating feature", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Delete(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	key := chi.URLParam(r, "key")
+	if key == "" {
+		http.Error(w, "not found feature key", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.service.Delete(context.Background(), key); err != nil {
+		logger.Error("Error deleting feature", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/feature/model.go
+++ b/internal/feature/model.go
@@ -1,0 +1,9 @@
+package feature
+
+// Feature represents a feature record.
+type Feature struct {
+	Key         string `json:"key" db:"key"`
+	Name        string `json:"name" db:"name"`
+	Description string `json:"description" db:"description"`
+	Unit        string `json:"unit" db:"unit"`
+}

--- a/internal/feature/repository.go
+++ b/internal/feature/repository.go
@@ -1,0 +1,78 @@
+package feature
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/jourloy/nutri-backend/internal/database"
+)
+
+type Repository interface {
+	Create(ctx context.Context, f Feature) (*Feature, error)
+	Update(ctx context.Context, f Feature) (*Feature, error)
+	Delete(ctx context.Context, key string) error
+}
+
+type repository struct {
+	db *sqlx.DB
+}
+
+func NewRepository() Repository {
+	return &repository{db: database.Database}
+}
+
+func (r *repository) Create(ctx context.Context, f Feature) (*Feature, error) {
+	const q = `
+        INSERT INTO features (key, name, description, unit)
+        VALUES (:key, :name, :description, :unit)
+        RETURNING key, name, description, unit;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, f)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var res Feature
+		if err := rows.StructScan(&res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Update(ctx context.Context, f Feature) (*Feature, error) {
+	const q = `
+        UPDATE features
+        SET name = :name, description = :description, unit = :unit
+        WHERE key = :key
+        RETURNING key, name, description, unit;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, f)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var res Feature
+		if err := rows.StructScan(&res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Delete(ctx context.Context, key string) error {
+	const q = `DELETE FROM features WHERE key = $1 RETURNING key;`
+
+	var deletedKey string
+	if err := r.db.GetContext(ctx, &deletedKey, q, key); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/feature/service.go
+++ b/internal/feature/service.go
@@ -1,0 +1,29 @@
+package feature
+
+import "context"
+
+type Service interface {
+	Create(ctx context.Context, f Feature) (*Feature, error)
+	Update(ctx context.Context, f Feature) (*Feature, error)
+	Delete(ctx context.Context, key string) error
+}
+
+type service struct {
+	repo Repository
+}
+
+func NewService() Service {
+	return &service{repo: NewRepository()}
+}
+
+func (s *service) Create(ctx context.Context, f Feature) (*Feature, error) {
+	return s.repo.Create(ctx, f)
+}
+
+func (s *service) Update(ctx context.Context, f Feature) (*Feature, error) {
+	return s.repo.Update(ctx, f)
+}
+
+func (s *service) Delete(ctx context.Context, key string) error {
+	return s.repo.Delete(ctx, key)
+}

--- a/internal/plan/controller.go
+++ b/internal/plan/controller.go
@@ -1,0 +1,153 @@
+package plan
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/log"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/jourloy/nutri-backend/internal/auth"
+)
+
+var (
+	logger = log.NewWithOptions(os.Stderr, log.Options{
+		Prefix: "[plan]",
+		Level:  log.DebugLevel,
+	})
+)
+
+type Controller struct {
+	service Service
+}
+
+func NewController() *Controller {
+	service := NewService()
+
+	return &Controller{service: service}
+}
+
+func (c *Controller) RegisterRoutes(router chi.Router) {
+	router.Route("/plan", func(r chi.Router) {
+		r.Post("/", c.Create)
+		r.Put("/", c.Update)
+		r.Delete("/{id}", c.Delete)
+		r.Get("/all", c.GetAll)
+	})
+
+	logger.Info("╔═════ Plan")
+	logger.Info("║   POST /")
+	logger.Info("║    PUT /")
+	logger.Info("║ DELETE /{id}")
+	logger.Info("║    GET /all")
+	logger.Info("╚═════")
+}
+
+func (c *Controller) GetAll(w http.ResponseWriter, r *http.Request) {
+	_, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	resp, err := c.service.GetAllActive(context.Background())
+	if err != nil {
+		logger.Error("Error get all plans", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Create(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	var pc PlanCreate
+	if err := json.NewDecoder(r.Body).Decode(&pc); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp, err := c.service.Create(context.Background(), pc)
+	if err != nil {
+		logger.Error("Error creating plan", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Update(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	var p Plan
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp, err := c.service.Update(context.Background(), p)
+	if err != nil {
+		logger.Error("Error updating plan", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Delete(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !u.IsAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	idParam := chi.URLParam(r, "id")
+	if idParam == "" {
+		http.Error(w, "not found plan id", http.StatusBadRequest)
+		return
+	}
+
+	id, err := strconv.ParseInt(idParam, 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := c.service.Delete(context.Background(), id); err != nil {
+		logger.Error("Error deleting plan", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/plan/model.go
+++ b/internal/plan/model.go
@@ -1,0 +1,36 @@
+package plan
+
+import "time"
+
+type Plan struct {
+	Id                int64     `json:"id" db:"id"`
+	Code              string    `json:"code" db:"code"`
+	Name              string    `json:"name" db:"name"`
+	PlanType          string    `json:"plan_type" db:"plan_type"`
+	Version           int       `json:"version" db:"version"`
+	Currency          string    `json:"currency" db:"currency"`
+	AmountMinor       int64     `json:"amount_minor" db:"amount_minor"`
+	BillingPeriod     string    `json:"billing_period" db:"billing_period"`
+	TrialDays         int       `json:"trial_days" db:"trial_days"`
+	ClientLimit       int       `json:"client_limit" db:"client_limit"`
+	IsActive          bool      `json:"is_active" db:"is_active"`
+	CreatedAt         time.Time `json:"-" db:"created_at"`
+	UpdatedAt         time.Time `json:"-" db:"updated_at"`
+	ExternalProductId *string   `json:"external_product_id,omitempty" db:"external_product_id"`
+	ExternalPriceId   *string   `json:"external_price_id,omitempty" db:"external_price_id"`
+}
+
+type PlanCreate struct {
+	Code            string  `json:"code" db:"code"`
+	Name            string  `json:"name" db:"name"`
+	PlanType        string  `json:"plan_type" db:"plan_type"`
+	Version         int     `json:"version" db:"version"`
+	Currency        string  `json:"currency" db:"currency"`
+	AmountMinor     int64   `json:"amount_minor" db:"amount_minor"`
+	BillingPeriod   string  `json:"billing_period" db:"billing_period"`
+	TrialDays       int     `json:"trial_days" db:"trial_days"`
+	ClientLimit     int     `json:"client_limit" db:"client_limit"`
+	IsActive        bool    `json:"is_active" db:"is_active"`
+	ExternalProduct *string `json:"external_product_id,omitempty" db:"external_product_id"`
+	ExternalPrice   *string `json:"external_price_id,omitempty" db:"external_price_id"`
+}

--- a/internal/plan/repository.go
+++ b/internal/plan/repository.go
@@ -1,0 +1,118 @@
+package plan
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/jourloy/nutri-backend/internal/database"
+)
+
+type Repository interface {
+	GetAllActive(ctx context.Context) ([]Plan, error)
+	Create(ctx context.Context, pc PlanCreate) (*Plan, error)
+	Update(ctx context.Context, p Plan) (*Plan, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+type repository struct {
+	db *sqlx.DB
+}
+
+func NewRepository() Repository {
+	return &repository{db: database.Database}
+}
+
+func (r *repository) GetAllActive(ctx context.Context) ([]Plan, error) {
+	const q = `
+        SELECT id, code, name, plan_type, version, currency,
+               amount_minor, billing_period, trial_days, client_limit,
+               is_active, created_at, updated_at, external_product_id, external_price_id
+        FROM plans
+        WHERE is_active = TRUE
+        ORDER BY amount_minor ASC`
+
+	var ps []Plan
+	if err := r.db.SelectContext(ctx, &ps, q); err != nil {
+		return nil, err
+	}
+	return ps, nil
+}
+
+func (r *repository) Create(ctx context.Context, pc PlanCreate) (*Plan, error) {
+	const q = `
+        INSERT INTO plans (
+                code, name, plan_type, version, currency, amount_minor,
+                billing_period, trial_days, client_limit, is_active,
+                external_product_id, external_price_id
+        ) VALUES (
+                :code, :name, :plan_type, :version, :currency, :amount_minor,
+                :billing_period, :trial_days, :client_limit, :is_active,
+                :external_product_id, :external_price_id
+        )
+        RETURNING id, code, name, plan_type, version, currency, amount_minor,
+                  billing_period, trial_days, client_limit, is_active,
+                  created_at, updated_at, external_product_id, external_price_id;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, pc)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var p Plan
+		if err := rows.StructScan(&p); err != nil {
+			return nil, err
+		}
+		return &p, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Update(ctx context.Context, p Plan) (*Plan, error) {
+	const q = `
+        UPDATE plans SET
+                code = :code,
+                name = :name,
+                plan_type = :plan_type,
+                version = :version,
+                currency = :currency,
+                amount_minor = :amount_minor,
+                billing_period = :billing_period,
+                trial_days = :trial_days,
+                client_limit = :client_limit,
+                is_active = :is_active,
+                external_product_id = :external_product_id,
+                external_price_id = :external_price_id,
+                updated_at = now()
+        WHERE id = :id
+        RETURNING id, code, name, plan_type, version, currency, amount_minor,
+                  billing_period, trial_days, client_limit, is_active,
+                  created_at, updated_at, external_product_id, external_price_id;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, p)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var res Plan
+		if err := rows.StructScan(&res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Delete(ctx context.Context, id int64) error {
+	const q = `DELETE FROM plans WHERE id = $1 RETURNING id;`
+
+	var deletedID int64
+	if err := r.db.GetContext(ctx, &deletedID, q, id); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/plan/service.go
+++ b/internal/plan/service.go
@@ -1,0 +1,34 @@
+package plan
+
+import "context"
+
+type Service interface {
+	GetAllActive(ctx context.Context) ([]Plan, error)
+	Create(ctx context.Context, pc PlanCreate) (*Plan, error)
+	Update(ctx context.Context, p Plan) (*Plan, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+type service struct {
+	repo Repository
+}
+
+func NewService() Service {
+	return &service{repo: NewRepository()}
+}
+
+func (s *service) GetAllActive(ctx context.Context) ([]Plan, error) {
+	return s.repo.GetAllActive(ctx)
+}
+
+func (s *service) Create(ctx context.Context, pc PlanCreate) (*Plan, error) {
+	return s.repo.Create(ctx, pc)
+}
+
+func (s *service) Update(ctx context.Context, p Plan) (*Plan, error) {
+	return s.repo.Update(ctx, p)
+}
+
+func (s *service) Delete(ctx context.Context, id int64) error {
+	return s.repo.Delete(ctx, id)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/jourloy/nutri-backend/internal/auth"
 	"github.com/jourloy/nutri-backend/internal/database"
+	"github.com/jourloy/nutri-backend/internal/feature"
 	"github.com/jourloy/nutri-backend/internal/fit"
 	"github.com/jourloy/nutri-backend/internal/middlewares"
+	"github.com/jourloy/nutri-backend/internal/plan"
 	"github.com/jourloy/nutri-backend/internal/product"
+	"github.com/jourloy/nutri-backend/internal/subscription"
 	"github.com/jourloy/nutri-backend/internal/template"
 	"github.com/jourloy/nutri-backend/internal/user"
 )
@@ -52,6 +55,9 @@ func Start() error {
 	auth.NewController().RegisterRoutes(r)
 	fit.NewController().RegisterRoutes(r)
 	product.NewController().RegisterRoutes(r)
+	plan.NewController().RegisterRoutes(r)
+	feature.NewController().RegisterRoutes(r)
+	subscription.NewController().RegisterRoutes(r)
 	template.NewController().RegisterRoutes(r)
 	logger.Debug("Handlers initialized", "latency", time.Since(tempTime))
 

--- a/internal/subscription/controller.go
+++ b/internal/subscription/controller.go
@@ -1,0 +1,120 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/log"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/jourloy/nutri-backend/internal/auth"
+)
+
+var (
+	logger = log.NewWithOptions(os.Stderr, log.Options{
+		Prefix: "[subs]",
+		Level:  log.DebugLevel,
+	})
+)
+
+type Controller struct {
+	service Service
+}
+
+func NewController() *Controller {
+	return &Controller{service: NewService()}
+}
+
+func (c *Controller) RegisterRoutes(router chi.Router) {
+	router.Route("/subscription", func(r chi.Router) {
+		r.Post("/", c.Create)
+		r.Put("/", c.Update)
+		r.Delete("/{id}", c.Delete)
+	})
+
+	logger.Info("╔═════ Subscription")
+	logger.Info("║   POST /")
+	logger.Info("║    PUT /")
+	logger.Info("║ DELETE /{id}")
+	logger.Info("╚═════")
+}
+
+func (c *Controller) Create(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var sc SubscriptionCreate
+	if err := json.NewDecoder(r.Body).Decode(&sc); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	sc.UserId = u.Id
+
+	resp, err := c.service.Create(context.Background(), sc)
+	if err != nil {
+		logger.Error("Error creating subscription", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Update(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var s Subscription
+	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.UserId = u.Id
+
+	resp, err := c.service.Update(context.Background(), s)
+	if err != nil {
+		logger.Error("Error updating subscription", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (c *Controller) Delete(w http.ResponseWriter, r *http.Request) {
+	u, ok := auth.UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	idParam := chi.URLParam(r, "id")
+	if idParam == "" {
+		http.Error(w, "not found subscription id", http.StatusBadRequest)
+		return
+	}
+	id, err := strconv.ParseInt(idParam, 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := c.service.Delete(context.Background(), id, u.Id); err != nil {
+		logger.Error("Error deleting subscription", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -1,0 +1,38 @@
+package subscription
+
+import "time"
+
+type Subscription struct {
+	Id                   int64      `json:"id" db:"id"`
+	UserId               string     `json:"user_id" db:"user_id"`
+	PlanId               int64      `json:"plan_id" db:"plan_id"`
+	Status               string     `json:"status" db:"status"`
+	PeriodStart          time.Time  `json:"period_start" db:"period_start"`
+	PeriodEnd            time.Time  `json:"period_end" db:"period_end"`
+	CancelAt             *time.Time `json:"cancel_at,omitempty" db:"cancel_at"`
+	CanceledAt           *time.Time `json:"canceled_at,omitempty" db:"canceled_at"`
+	TrialEnd             *time.Time `json:"trial_end,omitempty" db:"trial_end"`
+	AmountMinor          int64      `json:"amount_minor" db:"amount_minor"`
+	Currency             string     `json:"currency" db:"currency"`
+	BillingPeriod        string     `json:"billing_period" db:"billing_period"`
+	ExternalSubscription *string    `json:"external_subscription_id,omitempty" db:"external_subscription_id"`
+	ExternalCustomer     *string    `json:"external_customer_id,omitempty" db:"external_customer_id"`
+	CreatedAt            time.Time  `json:"-" db:"created_at"`
+	UpdatedAt            time.Time  `json:"-" db:"updated_at"`
+}
+
+type SubscriptionCreate struct {
+	PlanId               int64      `json:"plan_id" db:"plan_id"`
+	Status               string     `json:"status" db:"status"`
+	PeriodStart          time.Time  `json:"period_start" db:"period_start"`
+	PeriodEnd            time.Time  `json:"period_end" db:"period_end"`
+	CancelAt             *time.Time `json:"cancel_at,omitempty" db:"cancel_at"`
+	CanceledAt           *time.Time `json:"canceled_at,omitempty" db:"canceled_at"`
+	TrialEnd             *time.Time `json:"trial_end,omitempty" db:"trial_end"`
+	AmountMinor          int64      `json:"amount_minor" db:"amount_minor"`
+	Currency             string     `json:"currency" db:"currency"`
+	BillingPeriod        string     `json:"billing_period" db:"billing_period"`
+	ExternalSubscription *string    `json:"external_subscription_id,omitempty" db:"external_subscription_id"`
+	ExternalCustomer     *string    `json:"external_customer_id,omitempty" db:"external_customer_id"`
+	UserId               string     `json:"-" db:"user_id"`
+}

--- a/internal/subscription/repository.go
+++ b/internal/subscription/repository.go
@@ -1,0 +1,103 @@
+package subscription
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/jourloy/nutri-backend/internal/database"
+)
+
+type Repository interface {
+	Create(ctx context.Context, sc SubscriptionCreate) (*Subscription, error)
+	Update(ctx context.Context, s Subscription) (*Subscription, error)
+	Delete(ctx context.Context, id int64, uid string) error
+}
+
+type repository struct {
+	db *sqlx.DB
+}
+
+func NewRepository() Repository {
+	return &repository{db: database.Database}
+}
+
+func (r *repository) Create(ctx context.Context, sc SubscriptionCreate) (*Subscription, error) {
+	const q = `
+        INSERT INTO subscriptions (
+                user_id, plan_id, status, period_start, period_end,
+                cancel_at, canceled_at, trial_end, amount_minor, currency,
+                billing_period, external_subscription_id, external_customer_id
+        ) VALUES (
+                :user_id, :plan_id, :status, :period_start, :period_end,
+                :cancel_at, :canceled_at, :trial_end, :amount_minor, :currency,
+                :billing_period, :external_subscription_id, :external_customer_id
+        )
+        RETURNING id, user_id, plan_id, status, period_start, period_end,
+                  cancel_at, canceled_at, trial_end, amount_minor, currency,
+                  billing_period, external_subscription_id, external_customer_id,
+                  created_at, updated_at;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, sc)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var s Subscription
+		if err := rows.StructScan(&s); err != nil {
+			return nil, err
+		}
+		return &s, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Update(ctx context.Context, s Subscription) (*Subscription, error) {
+	const q = `
+        UPDATE subscriptions SET
+                plan_id = :plan_id,
+                status = :status,
+                period_start = :period_start,
+                period_end = :period_end,
+                cancel_at = :cancel_at,
+                canceled_at = :canceled_at,
+                trial_end = :trial_end,
+                amount_minor = :amount_minor,
+                currency = :currency,
+                billing_period = :billing_period,
+                external_subscription_id = :external_subscription_id,
+                external_customer_id = :external_customer_id,
+                updated_at = now()
+        WHERE id = :id AND user_id = :user_id
+        RETURNING id, user_id, plan_id, status, period_start, period_end,
+                  cancel_at, canceled_at, trial_end, amount_minor, currency,
+                  billing_period, external_subscription_id, external_customer_id,
+                  created_at, updated_at;`
+
+	rows, err := r.db.NamedQueryContext(ctx, q, s)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var res Subscription
+		if err := rows.StructScan(&res); err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+	return nil, nil
+}
+
+func (r *repository) Delete(ctx context.Context, id int64, uid string) error {
+	const q = `DELETE FROM subscriptions WHERE id = $1 AND user_id = $2 RETURNING id;`
+
+	var deletedID int64
+	if err := r.db.GetContext(ctx, &deletedID, q, id, uid); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -1,0 +1,29 @@
+package subscription
+
+import "context"
+
+type Service interface {
+	Create(ctx context.Context, sc SubscriptionCreate) (*Subscription, error)
+	Update(ctx context.Context, s Subscription) (*Subscription, error)
+	Delete(ctx context.Context, id int64, uid string) error
+}
+
+type service struct {
+	repo Repository
+}
+
+func NewService() Service {
+	return &service{repo: NewRepository()}
+}
+
+func (s *service) Create(ctx context.Context, sc SubscriptionCreate) (*Subscription, error) {
+	return s.repo.Create(ctx, sc)
+}
+
+func (s *service) Update(ctx context.Context, sub Subscription) (*Subscription, error) {
+	return s.repo.Update(ctx, sub)
+}
+
+func (s *service) Delete(ctx context.Context, id int64, uid string) error {
+	return s.repo.Delete(ctx, id, uid)
+}


### PR DESCRIPTION
## Summary
- extend plan module with create, update and delete endpoints restricted to admins
- add CRUD modules for features (admin-only) and subscriptions
- register new controllers in server

## Testing
- `go mod tidy` *(fails: github.com/jourloy/nutri-backend/cmd/server imports github.com/charmbracelet/log.test => github.com/stretchr/testify@v1.10.0: Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for module providing package github.com/charmbracelet/log)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2fe8ef1483249ec375e191ba6ec2